### PR TITLE
Allow installation in PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "description" : "Secure Trading's JSON API.",
   "license" : "MIT",
   "require" : {
-    "php" : "^7.3",
+    "php" : "^7.3 || ^8.0",
     "securetrading/exception" : "^1.0.1",
     "securetrading/ioc" : "^2.0",
     "securetrading/data" : "^2.0",


### PR DESCRIPTION
Hello, I noticed that versions 2.0 creates fix on `implode` call that triggers error in PHP 8 environment, but unfortunately composer.json restricts installation to php 7.3+ not including 8.