### PR TITLE
Laravel 10 Compatibility - Update to Logger

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,10 +1,10 @@
 {
   "name" : "securetrading/stpp_json",
-  "version" : "4.0.1",
+  "version" : "4.0.8",
   "description" : "Secure Trading's JSON API.",
   "license" : "MIT",
   "require" : {
-    "php" : "^8.1",
+    "php" : "^8.0",
     "securetrading/exception" : "^1.0.1",
     "securetrading/ioc" : "^3.0",
     "securetrading/data" : "^3.0",

--- a/src/Log.php
+++ b/src/Log.php
@@ -2,36 +2,43 @@
 
 namespace Securetrading\Stpp\JsonInterface;
 
-class Log extends \Psr\Log\AbstractLogger {
-  protected $_logger;
+use Stringable;
 
-  protected $_requestReference;
+class Log extends \Psr\Log\AbstractLogger
+{
+    protected $_logger;
 
-  public function setLogger(\Psr\Log\LoggerInterface $logger) {
-    $this->_logger = $logger;
-    return $this;
-  }
+    protected $_requestReference;
 
-  protected function _getLogger() {
-    if ($this->_logger === null) {
-      throw new LogException('The logger has not been set.', LogException::CODE_LOGGER_NOT_SET);
+    public function setLogger(\Psr\Log\LoggerInterface $logger)
+    {
+        $this->_logger = $logger;
+        return $this;
     }
-    return $this->_logger;
-  }
 
-  public function setRequestReference($requestReference) {
-    $this->_requestReference = $requestReference;
-    return $this;
-  }
+    protected function _getLogger()
+    {
+        if ($this->_logger === null) {
+            throw new LogException('The logger has not been set.', LogException::CODE_LOGGER_NOT_SET);
+        }
+        return $this->_logger;
+    }
 
-  public function log($logLevel, $message, array $context = array()) {
-    $message = $this->_formatMessage($message);
-    $this->_getLogger()->log($logLevel, $message, $context);
-    return $this;
-  }
+    public function setRequestReference($requestReference)
+    {
+        $this->_requestReference = $requestReference;
+        return $this;
+    }
 
-  protected function _formatMessage($message) {
-    $requestReference = $this->_requestReference ? $this->_requestReference : '   NOREF';
-    return sprintf('%s - %s', $requestReference, $message);
-  }
+    public function log($logLevel, Stringable|string $message, array $context = []): void
+    {
+        $message = $this->_formatMessage($message);
+        $this->_getLogger()->log($logLevel, $message, $context);
+    }
+
+    protected function _formatMessage($message)
+    {
+        $requestReference = $this->_requestReference ? $this->_requestReference : '   NOREF';
+        return sprintf('%s - %s', $requestReference, $message);
+    }
 }

--- a/src/Main.php
+++ b/src/Main.php
@@ -9,6 +9,8 @@ class Main {
     $ioc = \Securetrading\Ioc\Helper::instance()
       ->addVendorDirs(\Securetrading\Loader\Loader::getRootPath())
       ->addEtcDirs(realpath(__DIR__ . '/../etc'))
+       ->addEtcDirs(realpath(__DIR__ . '/../../securetrading-http/etc'))
+       ->addEtcDirs(realpath(__DIR__ . '/../../securetrading-log/etc'))
       ->loadPackage('stStppJson')
       ->getIoc();
     


### PR DESCRIPTION
Updates PSR Logger version, which allows the library to be used in Laravel 10.

Relies on :

https://github.com/SecureTrading/PHP-Log/pull/2
https://github.com/SecureTrading/PHP-Http/pull/1